### PR TITLE
Fix docs about Inline queries

### DIFF
--- a/_docs/create-bot.md
+++ b/_docs/create-bot.md
@@ -197,13 +197,13 @@ Here is the list of informations you need to send to create an inline query resp
 	},
 	"data" : {
 		"id" : "Message id",
-		"result" : {
+		"result" : [{
          "type" : "command",
          "title": "joke",
          "description": "tell a joke",
          "trigger": "/joke",
          "usage": "/joke"
-		}
+		}]
 	}
 }
 ```


### PR DESCRIPTION
https://talkspirit.github.io/docs/create-bot/

The Inline queries exemple had a mistake, `data.result` must be an array on object